### PR TITLE
Fix game over music and add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Echoavt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/janousek_escape.html
+++ b/janousek_escape.html
@@ -21,8 +21,8 @@
   <audio id="popupSound" src="https://github.com/Echoavt/Echoavt.github.io/raw/main/Y2Mate.is%20-%20Low%20quality%20spongebob%20screaming-JOyGvHtoMx8-128k-1654312463837.mp3" preload="auto"></audio>
   <!-- Titulní hudba (placeholder – nahraďte URL odkazem na vaši hudbu) -->
   <audio id="titleMusic" src="https://github.com/Echoavt/Echoavt.github.io/raw/main/bad-piggies-low-quality.mp3" preload="auto" loop></audio>
-  <!-- Hudba při prohře (placeholder – nahraďte URL odkazem na vaši hudbu) -->
-  <audio id="gameOverMusic" src="YOUR_GAMEOVER_MUSIC_URL" preload="auto" loop></audio>
+  <!-- Hudba při prohře -->
+  <audio id="gameOverMusic" src="bad-piggies-low-quality.mp3" preload="auto" loop></audio>
 </head>
 <body>
   <canvas id="gameCanvas" width="1280" height="720"></canvas>


### PR DESCRIPTION
## Summary
- add actual audio for the `gameOverMusic` tag
- include missing MIT license referenced in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684058357208832dbeca87980c30cb6b